### PR TITLE
Better naming

### DIFF
--- a/src/day02/part1.rs
+++ b/src/day02/part1.rs
@@ -1,4 +1,4 @@
-use super::shared::{Outcome, Throw};
+use super::shared::{Outcome, Shape};
 use crate::day02::{Input, Output};
 
 /// Solve part one
@@ -13,27 +13,27 @@ pub fn solve(input: &Input) -> Output {
         .into()
 }
 
-/// Trait for converting a character from the input into a `Throw`.
+/// Trait for converting a character from the input into a `Shape`.
 /// I'm using a Trait here so that I can use the same function names
 /// in the two different parts but have them behave differently, while 
 /// sharing some base functionality between parts.
-trait TryIntoThrow {
+trait TryIntoShape {
     type Error;
-    fn try_into_throw(&self) -> Result<Throw, Self::Error>;
+    fn try_into_shape(&self) -> Result<Shape, Self::Error>;
 }
 
-impl TryIntoThrow for char {
+impl TryIntoShape for char {
     type Error = &'static str;
 
-    /// Attempt to convert an input character into a `Throw`. Yes, we know
+    /// Attempt to convert an input character into a `Shape`. Yes, we know
     /// that there will be no other characters, but I like to practice good
     /// input hygiene when I can.
-    fn try_into_throw(&self) -> Result<Throw, Self::Error> {
+    fn try_into_shape(&self) -> Result<Shape, Self::Error> {
         match self {
-            'A' | 'X' => Ok(Throw::Rock),
-            'B' | 'Y' => Ok(Throw::Paper),
-            'C' | 'Z' => Ok(Throw::Scissors),
-            _ => Err("Character cannot be converted to `Throw`!"),
+            'A' | 'X' => Ok(Shape::Rock),
+            'B' | 'Y' => Ok(Shape::Paper),
+            'C' | 'Z' => Ok(Shape::Scissors),
+            _ => Err("Character cannot be converted to `Shape`!"),
         }
     }
 }
@@ -50,13 +50,13 @@ impl TryIntoOutcome for (char, char) {
 
     #[rustfmt::skip] // I _like_ my pretty match statement below
     fn try_into_outcome(&self) -> Result<Outcome, Self::Error> {
-        // Attempt to convert both characters into their respective `Throw`
+        // Attempt to convert both characters into their respective `Shape`
         let (ch1, ch2) = self;
-        let opponent = ch1.try_into_throw()?;
-        let player = ch2.try_into_throw()?;
+        let opponent = ch1.try_into_shape()?;
+        let player = ch2.try_into_shape()?;
 
-        // Based on the throws, determine who won and return the `Outcome`
-        use Throw::*;
+        // Based on the shapes, determine who won and return the `Outcome`
+        use Shape::*;
         let result = match (opponent, player) {
             (Rock,     Rock)     => Outcome::Draw(player),
             (Rock,     Paper)    => Outcome::Win(player),

--- a/src/day02/part2.rs
+++ b/src/day02/part2.rs
@@ -1,4 +1,4 @@
-use super::shared::{Outcome, Throw};
+use super::shared::{Outcome, Shape};
 use crate::day02::{Input, Output};
 
 /// Solve part two
@@ -13,27 +13,27 @@ pub fn solve(input: &Input) -> Output {
         .into()
 }
 
-/// Trait for converting a character from the input into a `Throw`.
+/// Trait for converting a character from the input into a `Shape`.
 /// I'm using a Trait here so that I can use the same function names
 /// in the two different parts but have them behave differently, while 
 /// sharing some base functionality between parts.
-trait TryIntoThrow {
+trait TryIntoShape {
     type Error;
-    fn try_into_throw(&self) -> Result<Throw, Self::Error>;
+    fn try_into_shape(&self) -> Result<Shape, Self::Error>;
 }
 
-impl TryIntoThrow for char {
+impl TryIntoShape for char {
     type Error = &'static str;
 
-    /// Attempt to convert an input character into a `Throw`. This time,
-    /// we know that 'X', 'Y', and 'Z' do not represent throws, so we don't
+    /// Attempt to convert an input character into a `Shape`. This time,
+    /// we know that 'X', 'Y', and 'Z' do not represent shapes, so we don't
     /// try to convert them.
-    fn try_into_throw(&self) -> Result<Throw, Self::Error> {
+    fn try_into_shape(&self) -> Result<Shape, Self::Error> {
         match self {
-            'A' => Ok(Throw::Rock),
-            'B' => Ok(Throw::Paper),
-            'C' => Ok(Throw::Scissors),
-            _ => Err("Character cannot be converted to `Throw`!"),
+            'A' => Ok(Shape::Rock),
+            'B' => Ok(Shape::Paper),
+            'C' => Ok(Shape::Scissors),
+            _ => Err("Character cannot be converted to `Shape`!"),
         }
     }
 }
@@ -50,15 +50,15 @@ impl TryIntoOutcome for (char, char) {
 
     #[rustfmt::skip] // I _still like_ my pretty match statement below
     fn try_into_outcome(&self) -> Result<Outcome, Self::Error> {
-        // Now, we only convert the first character into a `Throw`
+        // Now, we only convert the first character into a `Shape`
         let (ch1, result) = self;
-        let opponent = ch1.try_into_throw()?;
+        let opponent = ch1.try_into_shape()?;
 
         // Using the mapping that 'X' means we lose, 'Y' means we draw, and 
-        // 'Z' means we win, determine the outcome of the game and what throw
+        // 'Z' means we win, determine the outcome of the game and what shape
         // you the player need to make to achieve that outcome, and return 
         // the `Outcome`.
-        use Throw::*;
+        use Shape::*;
         match (opponent, result) {
             (Rock,     'Y') => Ok(Outcome::Draw(Rock)),
             (Rock,     'Z') => Ok(Outcome::Win(Paper)),

--- a/src/day02/shared.rs
+++ b/src/day02/shared.rs
@@ -1,46 +1,46 @@
-//! Common structs and functions for both parts. `Throw` and `Outcome`
+//! Common structs and functions for both parts. `Shape` and `Outcome`
 //! are used in both parts and the functionality for converting them into 
 //! points is unchanged between the parts.
 
-/// Represents a 'throw' in a game of Rock, Paper, Scissors
+/// Represents a 'shape' in a game of Rock, Paper, Scissors
 #[derive(Clone, Copy)]
-pub enum Throw {
+pub enum Shape {
     Rock,
     Paper,
     Scissors,
 }
 
-/// Convert a `Throw` into it's score value
-impl From<Throw> for u32 {
-    fn from(throw: Throw) -> Self {
-        match throw {
-            Throw::Rock => 1,
-            Throw::Paper => 2,
-            Throw::Scissors => 3,
+/// Convert a `Shape` into it's score value
+impl From<Shape> for u32 {
+    fn from(shape: Shape) -> Self {
+        match shape {
+            Shape::Rock => 1,
+            Shape::Paper => 2,
+            Shape::Scissors => 3,
         }
     }
 }
 
 /// Represents the outcome of a game of Rock, Paper, Scissors, from the
-/// perspective of you, the player. Each variant encapsulates the throw
+/// perspective of you, the player. Each variant encapsulates the shape
 /// you made to achieve that outcome.
 pub enum Outcome {
-    Win(Throw),
-    Draw(Throw),
-    Lose(Throw),
+    Win(Shape),
+    Draw(Shape),
+    Lose(Shape),
 }
 
 impl Outcome {
     /// Calculate the score from a given outcome
     pub fn score(&self) -> u32 {
         match self {
-            // 6 points for winning + the points for your throw
+            // 6 points for winning + the points for your shape
             Outcome::Win(t) => 6 + u32::from(*t),
 
-            // 3 points for a draw + the points for your throw
+            // 3 points for a draw + the points for your shape
             Outcome::Draw(t) => 3 + u32::from(*t),
 
-            // 0 points for losing + the points for your throw
+            // 0 points for losing + the points for your shape
             Outcome::Lose(t) => u32::from(*t),
         }
     }


### PR DESCRIPTION
Replace all instances of "Throw/throw" with "Shape/shape" to better match the puzzle text.